### PR TITLE
Ordered queries

### DIFF
--- a/rosapi/__init__.py
+++ b/rosapi/__init__.py
@@ -205,8 +205,8 @@ class BaseRouterboardResource(object):
 
     def call(self, command, set_kwargs, query_kwargs=None):
         query_kwargs = query_kwargs or {}
-        query_arguments = self._prepare_arguments(True, **query_kwargs)
-        set_arguments = self._prepare_arguments(False, **set_kwargs)
+        query_arguments = self._prepare_arguments(True, query_kwargs)
+        set_arguments = self._prepare_arguments(False, set_kwargs)
         query = ([('%s/%s' % (self.namespace, command)).encode('ascii')] +
                  query_arguments + set_arguments)
         response = self.api.api_client.talk(query)
@@ -219,7 +219,7 @@ class BaseRouterboardResource(object):
         return output
 
     @staticmethod
-    def _prepare_arguments(is_query, **kwargs):
+    def _prepare_arguments(is_query, kwargs):
         command_arguments = []
         for key, value in kwargs.items():
             if key in ['id', 'proplist']:


### PR DESCRIPTION
The Routerboard API documentation [states that query parameter order is significant](http://wiki.mikrotik.com/wiki/Manual:API#Queries), however the kwargs method was being used to send query parameters, and `dict` is inherently unordered, meaning that order of query parameters was not preserved.

It should be noted that the kwargs method also prevented multiple values being sent for a single query parameter, since keys in a dict are unique, meaning that the following example query found [in the documentation](http://wiki.mikrotik.com/wiki/Manual:API#Query_word) could not be made using this library:

    /interface/print
    ?type=ether
    ?type=vlan
    ?#|!

This pull request resolves these issues by introducing a new syntax for the `.get()` and `.detailed_get()` methods of a `RouterboardResource`. In addition to the previous syntax, which is still supported for backwards compatibility, a new syntax is introduced as follows:

```python
# Old syntax, doesn't preserve parameter order, no multiple values for parameters
# Still supported for backwards compatibility
resource.get(param1='value1', param2='value2')

# New syntax, order is preserved, multiple values can be specified for one parameter
resource.get( ('param', 'value'), ('param', 'value2') )
```

This syntax, although not as nice to look at, preserves ordering and allows for multiple values to be passed for a single query parameter by specifying it multiple times.