### PR TITLE
Fix socket.TCP_KEEPIDLE error on Mac OS

### DIFF
--- a/rosapi/__init__.py
+++ b/rosapi/__init__.py
@@ -1,11 +1,12 @@
 from __future__ import unicode_literals
 
 import binascii
-import hashlib
 import logging
 import socket
-import sys
 import ssl
+import sys
+
+from hashlib import md5
 
 from .retryloop import RetryError
 from .retryloop import retryloop
@@ -112,15 +113,12 @@ class RosAPI(object):
         self.socket = socket
         self.length_utils = RosApiLengthUtils(self)
 
-    def login(self, username, pwd):
+    def login(self, username, password):
         for _, attrs in self.talk([b'/login']):
             token = binascii.unhexlify(attrs[b'ret'])
-        hasher = hashlib.md5()
-        hasher.update(b'\x00')
-        hasher.update(pwd)
-        hasher.update(token)
+        md5_hash = md5(b'\x00' + password + token).hexdigest().encode('ascii')
         self.talk([b'/login', b'=name=' + username,
-                   b'=response=00' + hasher.hexdigest().encode('ascii')])
+                   b'=response=00' + md5_hash])
 
     def talk(self, words):
         if self.write_sentence(words) == 0:

--- a/rosapi/socket_utils.py
+++ b/rosapi/socket_utils.py
@@ -9,7 +9,11 @@ def set_keepalive(sock, after_idle_sec=1, interval_sec=3, max_fails=5):
     then sends a keepalive ping once every 3 seconds (interval_sec),
     and closes the connection after 5 failed ping (max_fails), or 15 seconds
     """
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, after_idle_sec)
-    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, interval_sec)
-    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, max_fails)
+    if hasattr(socket, "SO_KEEPALIVE"):
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+    if hasattr(socket, "TCP_KEEPIDLE"):
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, after_idle_sec)
+    if hasattr(socket, "TCP_KEEPINTVL"):
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, interval_sec)
+    if hasattr(socket, "TCP_KEEPCNT"):
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, max_fails)


### PR DESCRIPTION
`socket.TCP_KEEPIDLE` not available on Mac OS 10.12, so I check the attributes before it is used.
